### PR TITLE
Specify required AnnData version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+anndata==0.7rc2
 cellxgene==${CELLXGENE_VERSION}


### PR DESCRIPTION
The issue was caused by an outdated version on the AnnData dependency. Cellxgene seems to install version 0.6.22.post1, although I can't find where this is specified. Using any of the more recent versions (0.7rc1+) solved the issue with loading the file, but those following the 0.7 release cause the server to fail with 500 errors after successfully launching in the browser. Therefore, 0.7rc1 and 0.7rc2 are the only versions that work.